### PR TITLE
Change the way the rules are flushed/remove from the iptables.

### DIFF
--- a/user_filter/iptables_user_filter.sh
+++ b/user_filter/iptables_user_filter.sh
@@ -14,43 +14,44 @@ LAN_NETWORK="$LAN_NETWORK/$SUBNET_MASK" # Should be on the form 172.16.0.0/24
 
 # For multiple ports, separate by comma: 6881,6889
 # For port range, seperate by colon: 6881:6889
-BITTORRENT_LISTEN_PORTS=6881:6889
+BITTORRENT_LISTEN_PORTS=6881:6891
+
 
 DNS_PORT=53
 # Use google DNS servers
 DNS_IP1=8.8.4.4
 DNS_IP2=8.8.8.8
 
-iptables -F -t nat
-iptables -F -t mangle
-iptables -F -t filter
+#Remove iprules based on the custom comment we add with the rules.
+COMMENT="deluge-vpn"
+iptables-save | grep -v "${COMMENT}" | iptables-restore
 
 # Mark packets from $VPNUSER
-iptables -t mangle -A OUTPUT ! --dest $LAN_NETWORK  -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID
-iptables -t mangle -A OUTPUT --dest $LAN_NETWORK -p udp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID
-iptables -t mangle -A OUTPUT --dest $LAN_NETWORK -p tcp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID
-iptables -t mangle -A OUTPUT ! --src $LAN_NETWORK -j MARK --set-mark $MARK_ID
+iptables -t mangle -A OUTPUT ! --dest $LAN_NETWORK  -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID -m comment --comment "${COMMENT}"
+iptables -t mangle -A OUTPUT --dest $LAN_NETWORK -p udp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID -m comment --comment "${COMMENT}"
+iptables -t mangle -A OUTPUT --dest $LAN_NETWORK -p tcp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j MARK --set-mark $MARK_ID -m comment --comment "${COMMENT}"
+iptables -t mangle -A OUTPUT ! --src $LAN_NETWORK -j MARK --set-mark $MARK_ID -m comment --comment "${COMMENT}"
 
 # Allow responses
-iptables -A INPUT -i $VPNIF -m conntrack --ctstate ESTABLISHED -j ACCEPT
+iptables -A INPUT -i $VPNIF -m conntrack --ctstate ESTABLISHED -j ACCEPT -m comment --comment "${COMMENT}"
 
 # Allow bittorrent
-iptables -A INPUT -i $VPNIF -p tcp --match multiport --dport $BITTORRENT_LISTEN_PORTS -j ACCEPT
-iptables -A INPUT -i $VPNIF -p udp --match multiport --dport $BITTORRENT_LISTEN_PORTS -j ACCEPT
+iptables -A INPUT -i $VPNIF -p tcp --match multiport --dport $BITTORRENT_LISTEN_PORTS -j ACCEPT -m comment --comment "${COMMENT}"
+iptables -A INPUT -i $VPNIF -p udp --match multiport --dport $BITTORRENT_LISTEN_PORTS -j ACCEPT -m comment --comment "${COMMENT}"
 
 # Block everything incoming on $VPNIF
-iptables -A INPUT -i $VPNIF -j REJECT
+iptables -A INPUT -i $VPNIF -j REJECT -m comment --comment "${COMMENT}"
 
 # Set DNS for $VPNUSER
-iptables -t nat -A OUTPUT --dest $LAN_NETWORK -p udp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j DNAT --to-destination $DNS_IP1
-iptables -t nat -A OUTPUT --dest $LAN_NETWORK -p tcp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j DNAT --to-destination $DNS_IP2
+iptables -t nat -A OUTPUT --dest $LAN_NETWORK -p udp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j DNAT --to-destination $DNS_IP1 -m comment --comment "${COMMENT}"
+iptables -t nat -A OUTPUT --dest $LAN_NETWORK -p tcp --dport $DNS_PORT -m owner --uid-owner $VPNUSER -j DNAT --to-destination $DNS_IP2 -m comment --comment "${COMMENT}"
 
 # Let $VPNUSER access lo and $VPNIF
-iptables -A OUTPUT -o lo -m owner --uid-owner $VPNUSER -j ACCEPT
-iptables -A OUTPUT -o $VPNIF -m owner --uid-owner $VPNUSER -j ACCEPT
+iptables -A OUTPUT -o lo -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "${COMMENT}"
+iptables -A OUTPUT -o $VPNIF -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "${COMMENT}"
 
 # All packets on $VPNIF needs to be masqueraded
-iptables -t nat -A POSTROUTING -o $VPNIF -j MASQUERADE
+iptables -t nat -A POSTROUTING -o $VPNIF -j MASQUERADE -m comment --comment "${COMMENT}"
 
 # Reject connections from predator ip going over $NETIF
-iptables -A OUTPUT ! --src $LAN_NETWORK -o $NETIF -j REJECT
+iptables -A OUTPUT ! --src $LAN_NETWORK -o $NETIF -j REJECT -m comment --comment "${COMMENT}"


### PR DESCRIPTION
All the rules are now added with a custom comment, and we flush/remove
the rules by greping and removing the rules with that comment.

We do this do avoid flushing the rules setup by other scripts or configurations.

I've made this commit because the initial version was flushing ufw rules which was bad :s.